### PR TITLE
libssh: fix zig build

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -116,7 +116,18 @@ pub fn build(b: *std.Build) void {
             .WORDS_BIGENDIAN = false
         },
     );
+
+    const version_header = b.addConfigHeader(.{
+        .style = .{ .cmake = b.path("include/libssh/libssh_version.h.cmake") },
+        .include_path = "libssh_version.h"
+        }, .{
+        .LIBSSH_VERSION_MAJOR=0,
+        .LIBSSH_VERSION_MINOR=11,
+        .LIBSSH_VERSION_MICRO=0,
+    });
+
     lib.addConfigHeader(config_header);
+    lib.addConfigHeader(version_header);
 
     const dep_libmbedtls = b.dependency("libmbedtls", .{
         .target = target,
@@ -227,6 +238,7 @@ pub fn build(b: *std.Build) void {
     lib.linkLibC();
 
     lib.installHeadersDirectory(b.path("include/libssh"), "libssh", .{});
+    lib.installHeader(version_header.getOutput(), "libssh/libssh_version.h");
 
     b.installArtifact(lib);
 }

--- a/build.zig
+++ b/build.zig
@@ -121,9 +121,9 @@ pub fn build(b: *std.Build) void {
         .style = .{ .cmake = b.path("include/libssh/libssh_version.h.cmake") },
         .include_path = "libssh_version.h"
         }, .{
-        .LIBSSH_VERSION_MAJOR=0,
-        .LIBSSH_VERSION_MINOR=11,
-        .LIBSSH_VERSION_MICRO=0,
+        .libssh_VERSION_MAJOR=0,
+        .libssh_VERSION_MINOR=11,
+        .libssh_VERSION_PATCH=0,
     });
 
     lib.addConfigHeader(config_header);

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -27,5 +27,6 @@
         "build.zig.zon",
         "include",
         "config.h.cmake",
+        "src",
     },
 }

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -21,10 +21,11 @@
         },
     },
     .paths = .{
-        "LICENSE",
+        "COPYING",
         "README.md",
         "build.zig",
+        "build.zig.zon",
         "include",
-        "library",
+        "config.h.cmake",
     },
 }


### PR DESCRIPTION
- add libssh_version.h in zig build
- add missing and remove non-existing paths in zig.zon
- add 'src' to build.zig.zon
- fix version strings for libssh_version.h