### PR TITLE
Zig build v0.16 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ tags
 /obj*
 doc/tags.xml
 zig-out/*
+zig-pkg/*

--- a/build.zig
+++ b/build.zig
@@ -5,7 +5,7 @@ const Path = std.Build.LazyPath;
 pub fn build(b: *std.Build) void {
     const optimize = b.standardOptimizeOption(.{});
     const target = b.standardTargetOptions(.{});
-    const t = target.result;
+    const target_info = target.result;
     const with_server = b.option(bool, "WITH_SERVER", "Enable server-side APIs") orelse false;
 
     var lib = b.addLibrary(.{
@@ -77,15 +77,15 @@ pub fn build(b: *std.Build) void {
             .HAVE_POLL = true,
             .HAVE_SELECT = true,
             .HAVE_CLOCK_GETTIME = true,
-            .HAVE_NTOHLL = if (t.os.tag == .linux) false else true,
-            .HAVE_HTONLL = if (t.os.tag == .linux) false else true,
+            .HAVE_NTOHLL = if (target_info.os.tag == .linux) false else true,
+            .HAVE_HTONLL = if (target_info.os.tag == .linux) false else true,
             .HAVE_STRTOULL = true,
             .HAVE___STRTOULL = true,
             .HAVE__STRTOUI64 = true,
             .HAVE_GLOB = true,
             .HAVE_EXPLICIT_BZERO = false,
-            .HAVE_MEMSET_S = if (t.os.tag == .linux) false else true,
-            .HAVE_SECURE_ZERO_MEMORY = if (t.os.tag == .linux) false else true,
+            .HAVE_MEMSET_S = if (target_info.os.tag == .linux) false else true,
+            .HAVE_SECURE_ZERO_MEMORY = if (target_info.os.tag == .linux) false else true,
             .HAVE_CMOCKA_SET_TEST_FILTER = false,
 
             .HAVE_LIBCRYPTO = false,
@@ -131,11 +131,11 @@ pub fn build(b: *std.Build) void {
 
     const version_header = b.addConfigHeader(.{
         .style = .{ .cmake = b.path("include/libssh/libssh_version.h.cmake") },
-        .include_path = "libssh/libssh_version.h"
-        }, .{
-        .libssh_VERSION_MAJOR=0,
-        .libssh_VERSION_MINOR=11,
-        .libssh_VERSION_PATCH=0,
+        .include_path = "libssh/libssh_version.h",
+    }, .{
+        .libssh_VERSION_MAJOR = 0,
+        .libssh_VERSION_MINOR = 11,
+        .libssh_VERSION_PATCH = 0,
     });
 
     lib.addConfigHeader(config_header);

--- a/build.zig
+++ b/build.zig
@@ -8,10 +8,13 @@ pub fn build(b: *std.Build) void {
     const t = target.result;
     const with_server = b.option(bool, "WITH_SERVER", "Enable server-side APIs") orelse false;
 
-    var lib = b.addStaticLibrary(.{
+    var lib = b.addLibrary(.{
+        .linkage = .static,
         .name = "ssh",
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
     });
 
     const config_header = b.addConfigHeader(
@@ -20,6 +23,13 @@ pub fn build(b: *std.Build) void {
             .include_path = "config.h",
         },
         .{
+            .PACKAGE = "libssh",
+            .PROJECT_NAME = "libssh",
+            .VERSION = "0.11.0",
+            .PROJECT_VERSION = "0.11.0",
+            .SYSCONFDIR = "/etc",
+            .BINARYDIR = "/usr/bin",
+            .SOURCEDIR = "/usr/src",
             .GLOBAL_BIND_CONFIG = "/etc/ssh/libssh_server_config",
             .GLOBAL_CLIENT_CONFIG = "/etc/ssh/ssh_config",
             .HAVE_ARGP_H = true,
@@ -136,19 +146,13 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    var source_files = std.ArrayList([]const u8).init(b.allocator);
-    defer source_files.deinit();
-    var flags = std.ArrayList([]const u8).init(b.allocator);
-    defer flags.deinit();
-
-    flags.appendSlice(&.{
+    const flags: []const []const u8 = &.{
         "-Wall",
         "-Wextra",
         "-Wpedantic",
-        //"-Wno-long-long",
-    }) catch unreachable;
+    };
 
-    source_files.appendSlice(&.{
+    const base_sources: []const []const u8 = &.{
         "src/agent.c",
         "src/alloc.c",
         "src/auth.c",
@@ -197,59 +201,33 @@ pub fn build(b: *std.Build) void {
         "src/config_parser.c",
         "src/token.c",
         "src/pki_ed25519_common.c",
-    }) catch unreachable;
-
-    if (with_server) {
-        source_files.appendSlice(&.{
-            "src/server.c",
-            "src/bind.c",
-            "src/bind_config.c",
-        }) catch unreachable;
-    }
-
-    if (t.os.tag != .windows) {
-        source_files.appendSlice(&.{
-            "src/threads/noop.c",
-            "src/threads/pthread.c",
-        }) catch unreachable;
-    }
-
-    const mbedtls = true;
-    if (mbedtls) {
-        source_files.appendSlice(&.{
-            "src/threads/mbedtls.c",
-            "src/libmbedcrypto.c",
-            "src/mbedcrypto_missing.c",
-            "src/pki_mbedcrypto.c",
-            "src/ecdh_mbedcrypto.c",
-            "src/getrandom_mbedcrypto.c",
-            "src/md_mbedcrypto.c",
-            "src/dh_key.c",
-            "src/pki_ed25519.c",
-            "src/external/ed25519.c",
-            "src/external/fe25519.c",
-            "src/external/ge25519.c",
-            "src/external/sc25519.c",
-        }) catch unreachable;
-
-        source_files.appendSlice(&.{
-            "src/external/chacha.c",
-            "src/external/poly1305.c",
-            "src/chachapoly.c",
-        }) catch unreachable;
-
-        source_files.appendSlice(&.{
-            "src/external/curve25519_ref.c",
-        }) catch unreachable;
-
-        source_files.appendSlice(&.{
-            "src/dh-gex.c",
-        }) catch unreachable;
-    }
+        // mbedtls sources
+        "src/threads/mbedtls.c",
+        "src/libmbedcrypto.c",
+        "src/mbedcrypto_missing.c",
+        "src/pki_mbedcrypto.c",
+        "src/ecdh_mbedcrypto.c",
+        "src/getrandom_mbedcrypto.c",
+        "src/md_mbedcrypto.c",
+        "src/dh_key.c",
+        "src/pki_ed25519.c",
+        "src/external/ed25519.c",
+        "src/external/fe25519.c",
+        "src/external/ge25519.c",
+        "src/external/sc25519.c",
+        "src/external/chacha.c",
+        "src/external/poly1305.c",
+        "src/chachapoly.c",
+        "src/external/curve25519_ref.c",
+        "src/dh-gex.c",
+        // noop/pthread threads (non-windows)
+        "src/threads/noop.c",
+        "src/threads/pthread.c",
+    };
 
     lib.addCSourceFiles(.{
-        .files = source_files.items,
-        .flags = flags.items,
+        .files = base_sources,
+        .flags = flags,
     });
     lib.addIncludePath(b.path("include"));
     lib.linkLibrary(dep_libmbedtls.artifact("mbedcrypto"));

--- a/build.zig
+++ b/build.zig
@@ -22,111 +22,7 @@ pub fn build(b: *std.Build) void {
             .style = .{ .cmake = b.path("config.h.cmake") },
             .include_path = "config.h",
         },
-        .{
-            .PACKAGE = "libssh",
-            .PROJECT_NAME = "libssh",
-            .VERSION = "0.11.0",
-            .PROJECT_VERSION = "0.11.0",
-            .SYSCONFDIR = "/etc",
-            .BINARYDIR = "/usr/bin",
-            .SOURCEDIR = "/usr/src",
-            .GLOBAL_BIND_CONFIG = "/etc/ssh/libssh_server_config",
-            .GLOBAL_CLIENT_CONFIG = "/etc/ssh/ssh_config",
-            .HAVE_ARGP_H = true,
-            .HAVE_ARPA_INET_H = true,
-            .HAVE_GLOB_H = true,
-            .HAVE_VALGRIND_VALGRIND_H = false,
-            .HAVE_PTY_H = true,
-            .HAVE_UTMP_H = true,
-            .HAVE_UTIL_H = true,
-            .HAVE_LIBUTIL_H = true,
-            .HAVE_SYS_TIME_H = true,
-            .HAVE_SYS_UTIME_H = false,
-            .HAVE_IO_H = true,
-            .HAVE_TERMIOS_H = true,
-            .HAVE_UNISTD_H = true,
-            .HAVE_STDINT_H = true,
-            .HAVE_OPENSSL_AES_H = false,
-            .HAVE_WSPIAPI_H = true,
-            .HAVE_OPENSSL_BLOWFISH_H = false,
-            .HAVE_OPENSSL_DES_H = false,
-            .HAVE_OPENSSL_ECDH_H = false,
-            .HAVE_OPENSSL_EC_H = false,
-            .HAVE_OPENSSL_ECDSA_H = false,
-            .HAVE_PTHREAD_H = false,
-            .HAVE_OPENSSL_ECC = false,
-            .HAVE_GCRYPT_ECC = false,
-            .HAVE_ECC = true,
-            .HAVE_GLOB_GL_FLAGS_MEMBER = true,
-            .HAVE_GCRYPT_CHACHA_POLY = false,
-
-            .HAVE_OPENSSL_EVP_CHACHA20 = false,
-            .HAVE_OPENSSL_EVP_KDF_CTX = false,
-            .HAVE_OPENSSL_FIPS_MODE = false,
-            .HAVE_SNPRINTF = true,
-            .HAVE__SNPRINTF = true,
-            .HAVE__SNPRINTF_S = true,
-            .HAVE_VSNPRINTF = true,
-            .HAVE__VSNPRINTF = true,
-            .HAVE__VSNPRINTF_S = true,
-            .HAVE_ISBLANK = true,
-            .HAVE_STRNCPY = true,
-            .HAVE_STRNDUP = true,
-            .HAVE_CFMAKERAW = true,
-            .HAVE_GETADDRINFO = true,
-            .HAVE_POLL = true,
-            .HAVE_SELECT = true,
-            .HAVE_CLOCK_GETTIME = true,
-            .HAVE_NTOHLL = if (target_info.os.tag == .linux) false else true,
-            .HAVE_HTONLL = if (target_info.os.tag == .linux) false else true,
-            .HAVE_STRTOULL = true,
-            .HAVE___STRTOULL = true,
-            .HAVE__STRTOUI64 = true,
-            .HAVE_GLOB = true,
-            .HAVE_EXPLICIT_BZERO = false,
-            .HAVE_MEMSET_S = if (target_info.os.tag == .linux) false else true,
-            .HAVE_SECURE_ZERO_MEMORY = if (target_info.os.tag == .linux) false else true,
-            .HAVE_CMOCKA_SET_TEST_FILTER = false,
-
-            .HAVE_LIBCRYPTO = false,
-            .HAVE_LIBGCRYPT = false,
-            .HAVE_LIBMBEDCRYPTO = true,
-            .HAVE_PTHREAD = false,
-            .HAVE_CMOCKA = false,
-
-            .HAVE_GCC_THREAD_LOCAL_STORAGE = false,
-            .HAVE_MSC_THREAD_LOCAL_STORAGE = false,
-
-            .HAVE_FALLTHROUGH_ATTRIBUTE = true,
-            .HAVE_UNUSED_ATTRIBUTE = true,
-            .HAVE_WEAK_ATTRIBUTE = true,
-
-            .HAVE_CONSTRUCTOR_ATTRIBUTE = true,
-            .HAVE_DESTRUCTOR_ATTRIBUTE = true,
-
-            .HAVE_GCC_VOLATILE_MEMORY_PROTECTION = true,
-
-            .HAVE_COMPILER__FUNC__ = true,
-            .HAVE_COMPILER__FUNCTION__ = true,
-
-            .HAVE_GCC_BOUNDED_ATTRIBUTE = false,
-            .WITH_GSSAPI = false,
-            .WITH_ZLIB = false,
-            .WITH_SFTP = false,
-            .WITH_SERVER = with_server,
-            .WITH_GEX = true,
-            .WITH_INSECURE_NONE = true,
-            .WITH_BLOWFISH_CIPHER = false,
-            .DEBUG_CRYPTO = false,
-            .DEBUG_PACKET = false,
-            .WITH_PCAP = false,
-            .DEBUG_CALLTRACE = false,
-            .WITH_NACL = false,
-            .WITH_PKCS11_URI = true,
-            .WITH_PKCS11_PROVIDER = true,
-
-            .WORDS_BIGENDIAN = false
-        },
+        .{ .PACKAGE = "libssh", .PROJECT_NAME = "libssh", .VERSION = "0.11.0", .PROJECT_VERSION = "0.11.0", .SYSCONFDIR = "/etc", .BINARYDIR = "/usr/bin", .SOURCEDIR = "/usr/src", .GLOBAL_BIND_CONFIG = "/etc/ssh/libssh_server_config", .GLOBAL_CLIENT_CONFIG = "/etc/ssh/ssh_config", .HAVE_ARGP_H = true, .HAVE_ARPA_INET_H = true, .HAVE_GLOB_H = true, .HAVE_VALGRIND_VALGRIND_H = false, .HAVE_PTY_H = true, .HAVE_UTMP_H = true, .HAVE_UTIL_H = true, .HAVE_LIBUTIL_H = true, .HAVE_SYS_TIME_H = true, .HAVE_SYS_UTIME_H = false, .HAVE_IO_H = true, .HAVE_TERMIOS_H = true, .HAVE_UNISTD_H = true, .HAVE_STDINT_H = true, .HAVE_OPENSSL_AES_H = false, .HAVE_WSPIAPI_H = true, .HAVE_OPENSSL_BLOWFISH_H = false, .HAVE_OPENSSL_DES_H = false, .HAVE_OPENSSL_ECDH_H = false, .HAVE_OPENSSL_EC_H = false, .HAVE_OPENSSL_ECDSA_H = false, .HAVE_PTHREAD_H = false, .HAVE_OPENSSL_ECC = false, .HAVE_GCRYPT_ECC = false, .HAVE_ECC = true, .HAVE_GLOB_GL_FLAGS_MEMBER = true, .HAVE_GCRYPT_CHACHA_POLY = false, .HAVE_OPENSSL_EVP_CHACHA20 = false, .HAVE_OPENSSL_EVP_KDF_CTX = false, .HAVE_OPENSSL_FIPS_MODE = false, .HAVE_SNPRINTF = true, .HAVE__SNPRINTF = true, .HAVE__SNPRINTF_S = true, .HAVE_VSNPRINTF = true, .HAVE__VSNPRINTF = true, .HAVE__VSNPRINTF_S = true, .HAVE_ISBLANK = true, .HAVE_STRNCPY = true, .HAVE_STRNDUP = true, .HAVE_CFMAKERAW = true, .HAVE_GETADDRINFO = true, .HAVE_POLL = true, .HAVE_SELECT = true, .HAVE_CLOCK_GETTIME = true, .HAVE_NTOHLL = if (target_info.os.tag == .linux) false else true, .HAVE_HTONLL = if (target_info.os.tag == .linux) false else true, .HAVE_STRTOULL = true, .HAVE___STRTOULL = true, .HAVE__STRTOUI64 = true, .HAVE_GLOB = true, .HAVE_EXPLICIT_BZERO = false, .HAVE_MEMSET_S = if (target_info.os.tag == .linux) false else true, .HAVE_SECURE_ZERO_MEMORY = if (target_info.os.tag == .linux) false else true, .HAVE_CMOCKA_SET_TEST_FILTER = false, .HAVE_LIBCRYPTO = false, .HAVE_LIBGCRYPT = false, .HAVE_LIBMBEDCRYPTO = true, .HAVE_PTHREAD = false, .HAVE_CMOCKA = false, .HAVE_GCC_THREAD_LOCAL_STORAGE = false, .HAVE_MSC_THREAD_LOCAL_STORAGE = false, .HAVE_FALLTHROUGH_ATTRIBUTE = true, .HAVE_UNUSED_ATTRIBUTE = true, .HAVE_WEAK_ATTRIBUTE = true, .HAVE_CONSTRUCTOR_ATTRIBUTE = true, .HAVE_DESTRUCTOR_ATTRIBUTE = true, .HAVE_GCC_VOLATILE_MEMORY_PROTECTION = true, .HAVE_COMPILER__FUNC__ = true, .HAVE_COMPILER__FUNCTION__ = true, .HAVE_GCC_BOUNDED_ATTRIBUTE = false, .WITH_GSSAPI = false, .WITH_ZLIB = false, .WITH_SFTP = false, .WITH_SERVER = with_server, .WITH_GEX = true, .WITH_INSECURE_NONE = true, .WITH_BLOWFISH_CIPHER = false, .DEBUG_CRYPTO = false, .DEBUG_PACKET = false, .WITH_PCAP = false, .DEBUG_CALLTRACE = false, .WITH_NACL = false, .WITH_PKCS11_URI = true, .WITH_PKCS11_PROVIDER = true, .WORDS_BIGENDIAN = false },
     );
 
     const version_header = b.addConfigHeader(.{
@@ -138,8 +34,8 @@ pub fn build(b: *std.Build) void {
         .libssh_VERSION_PATCH = 0,
     });
 
-    lib.addConfigHeader(config_header);
-    lib.addConfigHeader(version_header);
+    lib.root_module.addConfigHeader(config_header);
+    lib.root_module.addConfigHeader(version_header);
 
     const dep_libmbedtls = b.dependency("libmbedtls", .{
         .target = target,
@@ -158,6 +54,8 @@ pub fn build(b: *std.Build) void {
         "src/auth.c",
         "src/base64.c",
         "src/bignum.c",
+        "src/bind.c",
+        "src/bind_config.c",
         "src/buffer.c",
         "src/callbacks.c",
         "src/channels.c",
@@ -189,6 +87,7 @@ pub fn build(b: *std.Build) void {
         "src/pki.c",
         "src/pki_container_openssh.c",
         "src/poll.c",
+        "src/server.c",
         "src/session.c",
         "src/scp.c",
         "src/socket.c",
@@ -225,18 +124,18 @@ pub fn build(b: *std.Build) void {
         "src/threads/pthread.c",
     };
 
-    lib.addCSourceFiles(.{
+    lib.root_module.addCSourceFiles(.{
         .files = base_sources,
         .flags = flags,
     });
-    lib.addIncludePath(b.path("include"));
-    lib.linkLibrary(dep_libmbedtls.artifact("mbedcrypto"));
-    lib.linkLibrary(dep_libmbedtls.artifact("mbedtls"));
-    lib.linkLibrary(dep_libmbedtls.artifact("mbedx509"));
-    lib.linkLibC();
+    lib.root_module.addIncludePath(b.path("include"));
+    lib.root_module.linkLibrary(dep_libmbedtls.artifact("mbedcrypto"));
+    lib.root_module.linkLibrary(dep_libmbedtls.artifact("mbedtls"));
+    lib.root_module.linkLibrary(dep_libmbedtls.artifact("mbedx509"));
+    lib.root_module.link_libc = true;
 
     lib.installHeadersDirectory(b.path("include/libssh"), "libssh", .{});
-    lib.installHeader(version_header.getOutput(), "libssh/libssh_version.h");
+    lib.installConfigHeader(version_header);
 
     b.installArtifact(lib);
 }

--- a/build.zig
+++ b/build.zig
@@ -146,13 +146,13 @@ pub fn build(b: *std.Build) void {
         .optimize = optimize,
     });
 
-    const flags: []const []const u8 = &.{
+    const flags = &.{
         "-Wall",
         "-Wextra",
         "-Wpedantic",
     };
 
-    const base_sources: []const []const u8 = &.{
+    const base_sources = &.{
         "src/agent.c",
         "src/alloc.c",
         "src/auth.c",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -17,7 +17,7 @@
     .dependencies = .{
         .libmbedtls = .{
             .url = "https://github.com/actonlang/mbedtls/archive/refs/heads/zig-build-v0.13.tar.gz",
-            .hash = "122064f9a1d07bc9e96f5abbae590727890e23691088c2daf038fdba3d4b108d5e24",
+            .hash = "1220beac3fc56317e137fcb1eaba5a292addfc8526eb2b43974225b7d356c9c8b234",
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,23 +1,11 @@
 .{
-    .name = "libssh",
-    // This is a [Semantic Version](https://semver.org/).
-    // In a future version of Zig it will be used for package deduplication.
+    .name = .libssh,
     .version = "0.11.0",
-
-    // This field is optional.
-    // This is currently advisory only; Zig does not yet do anything
-    // with this value.
-    //.minimum_zig_version = "0.11.0",
-
-    // This field is optional.
-    // Each dependency must either provide a `url` and `hash`, or a `path`.
-    // `zig build --fetch` can be used to fetch all dependencies of a package, recursively.
-    // Once all dependencies are fetched, `zig build` no longer requires
-    // internet connectivity.
+    .fingerprint = 0xda3551606a094491,
     .dependencies = .{
         .libmbedtls = .{
-            .url = "https://github.com/actonlang/mbedtls/archive/refs/heads/zig-build-v0.13.tar.gz",
-            .hash = "1220beac3fc56317e137fcb1eaba5a292addfc8526eb2b43974225b7d356c9c8b234",
+            .url = "https://github.com/actonlang/mbedtls/archive/refs/heads/zig-build-v0.15.tar.gz",
+            .hash = "N-V-__8AAKBbMwJvAtBVjQuHovpe9CAkkQycFm9-uwJLpzOJ",
         },
     },
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -4,8 +4,8 @@
     .fingerprint = 0xda3551606a094491,
     .dependencies = .{
         .libmbedtls = .{
-            .url = "https://github.com/actonlang/mbedtls/archive/refs/heads/zig-build-v0.15.tar.gz",
-            .hash = "N-V-__8AAKBbMwJvAtBVjQuHovpe9CAkkQycFm9-uwJLpzOJ",
+            .url = "https://github.com/precla/mbedtls/archive/refs/heads/zig-build-v0.16.tar.gz",
+            .hash = "N-V-__8AADpaMwJrbP9ictpUKuF90hLWOLYWJ817du7rgI3N",
         },
     },
     .paths = .{

--- a/include/libssh/libssh.h
+++ b/include/libssh/libssh.h
@@ -626,6 +626,7 @@ LIBSSH_API int ssh_get_random(void *where,int len,int strong);
 LIBSSH_API int ssh_get_version(ssh_session session);
 LIBSSH_API int ssh_get_status(ssh_session session);
 LIBSSH_API int ssh_get_poll_flags(ssh_session session);
+LIBSSH_API int ssh_session_handle_poll(ssh_session session, int revents);
 LIBSSH_API int ssh_init(void);
 LIBSSH_API int ssh_is_blocking(ssh_session session);
 LIBSSH_API int ssh_is_connected(ssh_session session);

--- a/include/libssh/libssh.h
+++ b/include/libssh/libssh.h
@@ -500,6 +500,8 @@ LIBSSH_API int ssh_channel_open_x11(ssh_channel channel, const char *orig_addr, 
 LIBSSH_API int ssh_channel_poll(ssh_channel channel, int is_stderr);
 LIBSSH_API int ssh_channel_poll_timeout(ssh_channel channel, int timeout, int is_stderr);
 LIBSSH_API int ssh_channel_read(ssh_channel channel, void *dest, uint32_t count, int is_stderr);
+LIBSSH_API int ssh_channel_read_buffered(ssh_channel channel, void *dest, uint32_t count,
+    int is_stderr);
 LIBSSH_API int ssh_channel_read_timeout(ssh_channel channel, void *dest, uint32_t count, int is_stderr, int timeout_ms);
 LIBSSH_API int ssh_channel_read_nonblocking(ssh_channel channel, void *dest, uint32_t count,
     int is_stderr);

--- a/src/ABI/libssh-4.10.0.symbols
+++ b/src/ABI/libssh-4.10.0.symbols
@@ -171,6 +171,7 @@ ssh_channel_open_x11
 ssh_channel_poll
 ssh_channel_poll_timeout
 ssh_channel_read
+ssh_channel_read_buffered
 ssh_channel_read_nonblocking
 ssh_channel_read_timeout
 ssh_channel_request_auth_agent

--- a/src/channels.c
+++ b/src/channels.c
@@ -3170,6 +3170,89 @@ int ssh_channel_read_timeout(ssh_channel channel,
 }
 
 /**
+ * @brief Reads buffered data from a channel without polling the socket.
+ *
+ * @param[in]  channel   The channel to read from.
+ *
+ * @param[out] dest      The destination buffer which will get the data.
+ *
+ * @param[in]  count     The count of bytes to be read.
+ *
+ * @param[in]  is_stderr A boolean value to mark reading from the stderr flow.
+ *
+ * @return               The number of bytes read, SSH_AGAIN if nothing is
+ *                       available, SSH_ERROR on error, and SSH_EOF if the
+ *                       channel is EOF.
+ */
+int ssh_channel_read_buffered(ssh_channel channel,
+                              void *dest,
+                              uint32_t count,
+                              int is_stderr)
+{
+    ssh_session session;
+    ssh_buffer stdbuf;
+    uint32_t len;
+
+    if (channel == NULL) {
+        return SSH_ERROR;
+    }
+    if (dest == NULL) {
+        ssh_set_error_invalid(channel->session);
+        return SSH_ERROR;
+    }
+
+    session = channel->session;
+    if (count == 0) {
+        return 0;
+    }
+
+    stdbuf = channel->stdout_buffer;
+    if (is_stderr) {
+        stdbuf = channel->stderr_buffer;
+    }
+
+    if (session->session_state == SSH_SESSION_STATE_ERROR) {
+        return SSH_ERROR;
+    }
+
+    if (channel->state == SSH_CHANNEL_STATE_CLOSED) {
+        ssh_set_error(session,
+                      SSH_FATAL,
+                      "Remote channel is closed.");
+        return SSH_ERROR;
+    }
+
+    len = ssh_buffer_get_len(stdbuf);
+    if (len == 0) {
+        if (channel->remote_eof) {
+            return SSH_EOF;
+        }
+        return SSH_AGAIN;
+    }
+
+    if (len > count) {
+        len = count;
+    }
+
+    memcpy(dest, ssh_buffer_get(stdbuf), len);
+    ssh_buffer_pass_bytes(stdbuf, len);
+    if (channel->counter != NULL) {
+        channel->counter->in_bytes += len;
+    }
+
+    /* Try completing the delayed_close */
+    if (channel->delayed_close && !ssh_channel_has_unread_data(channel)) {
+        channel->state = SSH_CHANNEL_STATE_CLOSED;
+    }
+
+    if (grow_window(session, channel) == SSH_ERROR) {
+        return SSH_ERROR;
+    }
+
+    return len;
+}
+
+/**
  * @brief Do a nonblocking read on the channel.
  *
  * A nonblocking read on the specified channel. it will return <= count bytes of

--- a/src/libssh.map
+++ b/src/libssh.map
@@ -224,6 +224,7 @@ LIBSSH_4_5_0    # Released
         ssh_get_log_userdata;
         ssh_get_openssh_version;
         ssh_get_poll_flags;
+        ssh_session_handle_poll;
         ssh_get_pubkey;
         ssh_get_pubkey_hash;
         ssh_get_publickey;

--- a/src/libssh.map
+++ b/src/libssh.map
@@ -157,6 +157,7 @@ LIBSSH_4_5_0    # Released
         ssh_channel_poll;
         ssh_channel_poll_timeout;
         ssh_channel_read;
+        ssh_channel_read_buffered;
         ssh_channel_read_nonblocking;
         ssh_channel_read_timeout;
         ssh_channel_request_auth_agent;

--- a/src/session.c
+++ b/src/session.c
@@ -886,6 +886,31 @@ int ssh_get_poll_flags(ssh_session session)
   return ssh_socket_get_poll_flags (session->socket);
 }
 
+int ssh_session_handle_poll(ssh_session session, int revents)
+{
+    ssh_poll_handle ph;
+    int rc;
+
+    if (session == NULL || session->socket == NULL) {
+        return SSH_ERROR;
+    }
+
+    ph = ssh_socket_get_poll_handle(session->socket);
+    if (ph == NULL) {
+        return SSH_ERROR;
+    }
+
+    rc = ssh_socket_pollcallback(ph,
+                                 ssh_socket_get_fd(session->socket),
+                                 revents,
+                                 session->socket);
+    if (rc < 0) {
+        return SSH_ERROR;
+    }
+
+    return SSH_OK;
+}
+
 /**
  * @brief Get the disconnect message from the server.
  *


### PR DESCRIPTION
Includes commits from https://github.com/actonlang/libssh/pull/4

mbedtls path currently points to my fork, since that is also adapted for zig 0.16.0

needs this to be merged into actonlang/mbedtls : https://github.com/actonlang/mbedtls/pull/1